### PR TITLE
Updated the docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,8 +26,8 @@ The full documentation is at https://django-rest-framework-recaptcha.readthedocs
 Requirements
 ------------
 
-* Python: 2.7, 3.4, 3.5, 3.6, 3.7
-* Django: 1.10, 1.11, 2.0, 2.1
+* Python: 2.7, 3.4, 3.5, 3.6, 3.7, 3.9, 3.10
+* Django: 1.10, 1.11, 2.0, 2.1, 3.0+, 4.0
 * Django REST framework: 3.4, 3.5, 3.6, 3.7, 3.8, 3.9
 
 Installation
@@ -79,7 +79,7 @@ serializer. For example:
 .. code-block:: python
 
     from rest_framework import serializers
-    from rest_framework_recaptcha import ReCaptchaField
+    from rest_framework_recaptcha.fields import ReCaptchaField
 
 
     class MySerializer(serializers.Serializer):


### PR DESCRIPTION
I realized that the Django REST framework reCAPTCHA also works on Django 3.0 and higher. This was not in the docs. I also realized that ReCaptchaField had already been moved to rest_framework_recaptcha.fields and isn't in rest_framework_recaptcha as the current docs suggests.